### PR TITLE
Update output step in GitHub workflow and update docs

### DIFF
--- a/.github/workflows/usage-example.yml
+++ b/.github/workflows/usage-example.yml
@@ -32,7 +32,7 @@ jobs:
         run: echo "${{ steps.release-notes.outputs.notes }}"
 
       - name: Write to File
-        run: echo "${{ steps.generate-notes.outputs.notes }}" > release_notes.txt
+        run: echo "${{ steps.release-notes.outputs.notes }}" > release_notes.txt
 
       - name: Upload Release Notes
         uses: actions/upload-artifact@v2

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -36,11 +36,23 @@ To use this action in your workflow, add the following step:
 
 ```markdown
 ## What's Changed
-  * Enhancements: Features, Customization, and Contributor Detection by @GabLeRoux in https://github.com/GabLeRoux/generate-github-release-notes/pull/4
-  * npm run build by @GabLeRoux in https://github.com/GabLeRoux/generate-github-release-notes/pull/5
-  
-  **Full Changelog**: [https://github.com/GabLeRoux/generate-github-release-notes/compare/v0.0.2...v0.0.3](https://github.com/GabLeRoux/generate-github-release-notes/compare/v0.0.2...v0.0.3)
+* Enhancements: Features, Customization, and Contributor Detection by @GabLeRoux in https://github.com/GabLeRoux/generate-github-release-notes/pull/4
+* npm run build by @GabLeRoux in https://github.com/GabLeRoux/generate-github-release-notes/pull/5
+
+**Full Changelog**: [https://github.com/GabLeRoux/generate-github-release-notes/compare/v0.0.2...v0.0.3](https://github.com/GabLeRoux/generate-github-release-notes/compare/v0.0.2...v0.0.3)
 ```
+
+### Rendered output example
+
+---
+
+## What's Changed
+* Enhancements: Features, Customization, and Contributor Detection by @GabLeRoux in https://github.com/GabLeRoux/generate-github-release-notes/pull/4
+* npm run build by @GabLeRoux in https://github.com/GabLeRoux/generate-github-release-notes/pull/5
+
+**Full Changelog**: [https://github.com/GabLeRoux/generate-github-release-notes/compare/v0.0.2...v0.0.3](https://github.com/GabLeRoux/generate-github-release-notes/compare/v0.0.2...v0.0.3)
+
+---
 
 ## Contributing
 


### PR DESCRIPTION
Fixed the command in the "Write to File" step of the GitHub workflow. The output of the "release-notes" step is now correctly directed to the "release_notes.txt" file. This ensures accurate content for release notes in the generated file.
